### PR TITLE
Add agents guide and expand roadmap

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Initial setup of agents files and updated documentation.

--- a/.dev/tasks.md
+++ b/.dev/tasks.md
@@ -1,0 +1,11 @@
+# Development Tasks
+
+This list helps human and AI contributors coordinate work.
+
+- [ ] Set up Telegram bot with Telegraf.js
+- [ ] Configure PocketBase with required collections
+- [ ] Implement `/start` onboarding flow
+- [ ] Add journaling feature
+- [ ] Add work mode with Pomodoro cycles
+- [ ] Implement habit tracking
+- [ ] Show daily dashboard summary

--- a/README.md
+++ b/README.md
@@ -1,109 +1,217 @@
-# 🧠 Telo – Telegram Productivity Bot
+# TELO - Telegram-Based Mindful Assistant
 
-**Telo** is a stateless, menu-based Telegram bot built with Node.js (`telegraf`) and PocketBase to help you:
+## Project Overview
 
-- Reflect through journal prompts
-- Plan your day
-- Run work cycles
-- Take intentional breaks
-- Save and manage inspirational quotes
+TELO is a minimalist, Telegram-based assistant that helps users become more self-aware, intentional, and consistent with their personal habits, journaling, and work/break cycles. It functions as a conversational behavioral companion that operates entirely within Telegram. The backend is powered by **Node.js** and **PocketBase**, making it easy to deploy, fast to build, and scalable for future enhancements.
 
-It uses inline buttons, a clean callback system, and stores data via PocketBase’s REST API. Ideal for anyone seeking a minimalist productivity assistant.
+TELO is designed to support a vision of **conscious work and living**, encouraging users to act, reflect, and grow with intention throughout their day.
 
 ---
 
-## 🚀 Features
+## Core Philosophy
 
-- 🧭 Stateless Telegram menu navigation
-- ✍️ Journal routines (e.g. Morning, Evening)
-- 💼 Work mode setup: task, duration, cycles
-- ☕ Break mode: select type and time
-- 💬 Quotes: view, create, delete
-- 🔌 PocketBase backend (self-hosted)
-- 🌐 Deployed via Dokploy (free-tier friendly)
+> "What is measured improves. What is repeated becomes part of you."
 
----
+TELO is designed to:
 
-## 📂 Folder Structure
-
-```
-telegram_pocketbase_bot/
-├── index.js                      # Core bot logic
-├── package.json                  # Node dependencies
-├── .env.example                  # Sample env variables
-├── Procfile                      # Dokploy process config
-├── pb_schema_journal_entries.json # PocketBase collection schema
-└── README.md
-```
+* Anchor users with a personal goal and daily inspirational quotes
+* Guide them through reflection via journaling routines
+* Provide Pomodoro-style work and break sessions
+* Track custom habits throughout the day
 
 ---
 
-## 🔧 Environment Setup
+## Tech Stack
 
-1. **Install dependencies**
+* **Frontend**: Telegram Bot (using [Telegraf.js](https://telegraf.js.org/))
+* **Backend**: Node.js with PocketBase (local-first database with REST/Realtime support)
+* **Storage**: PocketBase collections for users, habits, journal entries, work logs, etc.
+* **Hosting Options**: Railway, Render, Fly.io, or local dev using ngrok
+
+---
+
+## Major Features
+
+### 1. User Onboarding
+
+* Triggered via `/start`
+* Prompts user to set a personal goal
+* Prompts user to add 1-3 quotes
+* Prompts user to add 1 good habit and 1 bad habit
+* Saves data into `users` collection in PocketBase
+
+### 2. Work Mode (Aware Pomodoro)
+
+* User chooses a total session length (e.g., 2 hours)
+* User chooses sprint length (e.g., 25 minutes)
+* After each sprint:
+
+  * User logs how they felt
+  * Bot suggests a break from a random list
+  * Break duration is chosen (e.g., 5 mins)
+  * Loop continues until session ends
+
+### 3. Break Mode
+
+* User selects a break activity or receives a random one
+* Selects break duration
+* Optionally reflects after break
+
+### 4. Journaling
+
+* Two modes:
+
+  * **View Mode**: Flip through entries day-by-day
+  * **Write Mode**: Guided (morning/midday/evening) or free-form entry
+* Entries are timestamped and stored in `journal_entries` collection
+
+### 5. Habit Tracking
+
+* User defines habits as good or bad
+* Can log `+1` or `-1` at any time via buttons
+* Counts reset daily (can be automated or triggered)
+* Stored in `habit_logs` or inline under user object depending on scale
+
+### 6. Dashboard
+
+* Shows a summary of the current day:
+
+  * Work time
+  * Sprints completed
+  * Breaks taken
+  * Habit counts
+  * Journal entries
+* Supports flipping through dates with buttons
+
+### 7. Utilities Section
+
+* Manage habits, quotes, goals, work/break categories
+* Export data
+* Wipe/reset account
+
+---
+
+## PocketBase Collections Design
+
+### `users`
+
+* `id` (Telegram ID)
+* `first_name`, `username`
+* `goal`: string
+* `quotes`: array of strings
+* `habits`: array of objects `{ name, type, count_today }`
+* `created_at`, `updated_at`
+
+### `journal_entries`
+
+* `id`, `user` (relation)
+* `date`: string (YYYY-MM-DD)
+* `type`: string ("Morning", "Evening", "Free")
+* `content`: text
+
+### `habit_logs` (if needed)
+
+* `user` (relation)
+* `habit_name`: string
+* `date`: string
+* `count`: number
+
+### `work_sessions`
+
+* `user` (relation)
+* `date`
+* `total_minutes`
+* `sprint_count`
+* `reflections`: array of short entries
+
+---
+
+## File Structure Example
 
 ```bash
-npm install
-```
-
-2. **Copy and configure your .env file**
-
-```bash
-cp .env.example .env
-```
-
-Update it with:
-
-```env
-BOT_TOKEN=your_telegram_bot_token
-POCKETBASE_URL=http://your-pocketbase-url
+/telo
+├── index.js             # Entry point
+├── bot.js               # Telegram bot logic using Telegraf
+├── pb.js                # PocketBase SDK wrapper
+├── workflows/
+│   ├── onboarding.js
+│   ├── journal.js
+│   ├── habits.js
+│   ├── workmode.js
+│   ├── breakmode.js
+│   └── dashboard.js
+└── utils/
+    └── time.js
 ```
 
 ---
 
-## 🧠 How It Works
+## Development Roadmap
 
-This bot uses inline buttons with `callback_data` like:
+### 🛠 Phase 1: MVP – Core Awareness System (2–3 weeks)
 
-```
-flow=journal;step=1
-```
+**User Story**: As a new user, I want to onboard easily, track my habits, write in my journal, and focus during my work sessions so I can become more intentional in how I spend my day.
 
-Your bot parses this data and decides what to show next, using logic in `index.js`.
+**Features**
+- `/start` onboarding: set personal goal, add up to 3 quotes, define 1 good habit and 1 bad habit
+- Work mode: choose total session and sprint length, reflect after each sprint, random break with selectable duration
+- Break mode: choose break type and duration, optional reflection
+- Habit tracking: view habits, +1/-1 logs, daily reset
+- Journaling: Morning/Evening/Free entries with day navigation
+- Dashboard: summary of work time, sprints, habits, journal entries
+- **Technical Tasks**: PocketBase collections, Telegraf.js bot scaffolding, message templates, local testing via ngrok or Railway
 
-Only important entries like **journal submissions** or **quotes** are stored in PocketBase.
+### 🧪 Phase 2: Power Features – Personalization Layer (3–4 weeks)
+
+**User Story**: As a regular user, I want to customize my journal routines, break types, and quote behavior so TELO feels more like a personal coach.
+
+**Features**
+- Custom journal routines with user questions
+- Editable work and break categories
+- Custom sprint and break durations
+- Habit streaks and optional reminders
+- Favorite quotes and rotation logic
+- View journals by type and across days
+- Export logs to CSV or Google Sheets
+- Search journal entries
+- **Technical Tasks**: new collections for routines, fields for work_types/break_types, enhance `/journal` and habit logic, implement `/export`, index journal content
+
+### 🤖 Phase 3: Reflection + AI Companion (Optional Extension)
+
+**User Story**: As a deep user, I want AI-driven reflections and summaries so TELO can provide insights from my data.
+
+**Features**
+- AI summaries of journal entries
+- Weekly reports of work time, moods, habits
+- Conversational replies after journaling
+- Mood pattern recognition with insights
+- Quote suggestions based on entry tone
+- **Technical Tasks**: store AI responses, mood_tag and ai_summary fields, integrate OpenAI or local LLM, `/review` command
 
 ---
 
-## 💾 PocketBase Setup
+## Dev Tips for Junior Developers
 
-1. Download from [https://pocketbase.io](https://pocketbase.io)
-2. Run it locally:
-
-```bash
-./pocketbase serve
-```
-
-3. Import the schema:
-
-- Go to `http://localhost:8090/_/`
-- Create collection using fields from `pb_schema_journal_entries.json`
+* **Telegraf.js** has excellent docs and is beginner-friendly
+* **PocketBase** can be self-hosted with one binary and provides REST & realtime APIs
+* Focus on **one command at a time** — make `/start` onboarding work perfectly before moving to journal
+* Use `console.log()` to debug payloads coming from Telegram
+* Use environment variables to store your Telegram bot token and PocketBase URL
+* Keep your `user_id` in every DB call to scope all actions
 
 ---
 
-## ☁️ Deploying to Dokploy
+## Final Notes
 
-1. Push this project to GitHub
-2. Go to [dokploy.io](https://dokploy.io)
-3. Connect your GitHub repo
-4. Set environment variables:
-   - `BOT_TOKEN`
-   - `POCKETBASE_URL`
-5. Dokploy will auto-deploy your bot
+TELO isn’t just another productivity tool. It’s a **daily reflection mirror**, a **mini-habit coach**, and a **guided awareness builder** — all inside Telegram.
 
----
+When built right, this can scale into:
 
+* A lightweight mental health tool
+* A mindfulness training assistant
+* A personal development SaaS with Telegram as the UI
 
-## 📄 License
+Start simple. Build well. Stay human-focused.
 
-MIT – free to use and extend.
+> Want to focus? Breathe first. Then type `/work`.
+

--- a/agents.txt
+++ b/agents.txt
@@ -1,0 +1,6 @@
+This file is used by AI agents working on the TELO project.
+It provides a single place for meta instructions and quick reference.
+
+- Review the README for project goals and roadmap.
+- Check the .dev/tasks.md file for current development tasks.
+- Log noteworthy changes in .dev/CHANGELOG.md.

--- a/agents.txt
+++ b/agents.txt
@@ -1,6 +1,82 @@
-This file is used by AI agents working on the TELO project.
-It provides a single place for meta instructions and quick reference.
+# TELO - AI Coding Agent Instructions
 
-- Review the README for project goals and roadmap.
-- Check the .dev/tasks.md file for current development tasks.
-- Log noteworthy changes in .dev/CHANGELOG.md.
+This file provides meta instructions for AI agents working on the TELO project. It defines how agents should access context, where to log work, and how to handle schema and logic consistency.
+
+---
+
+## 🔧 Primary Files & Responsibilities
+
+| File                | Purpose                                                          |
+| ------------------- | ---------------------------------------------------------------- |
+| `README.md`         | Project overview, vision, goals, and high-level roadmap          |
+| `.dev/tasks.md`     | Active development tasks, WIP features, and priority items       |
+| `.dev/CHANGELOG.md` | Log of meaningful changes in features, structure, or schema      |
+| `.dev/schema.json`  | PocketBase-friendly full schema definition (always up to date)   |
+| `pb.js`             | PocketBase connection utility, all schema helpers reference this |
+| `/workflows/`       | All feature logic (e.g., onboarding, journal, work mode)         |
+
+---
+
+## 🧠 Core Workflow Instructions
+
+### 1. Project Context Access
+
+* Always read `README.md` before performing roadmap-level work
+* Pull the latest logic and user flows from `workflows/*.js`
+* Reference `tasks.md` to prioritize what to work on
+
+### 2. Logging Protocol
+
+* All meaningful changes must be recorded in `.dev/CHANGELOG.md`
+* Each PR/commit should include a short changelog entry
+
+### 3. Schema Maintenance
+
+* Any change to PocketBase collections **must** be reflected in `schema.json`
+* Update the schema manually or via CLI script if schema evolves
+* Validate consistency between:
+
+  * Collection names
+  * Field types and options
+  * Relations and unique constraints
+
+### 4. Bot Behavior Rules
+
+* All logic must key off `user_id` from Telegram
+* Always wrap outbound messages and button rows in helpers for easy reuse
+* Keep message structure declarative: content + inline buttons grouped by logic
+* Use `reply_markup` for inline buttons; `force_reply` for required free text
+
+### 5. Journal + AI Agents
+
+* When generating journal reflections or summaries:
+
+  * Pull the last 3–5 entries
+  * Reference user's `goal` and tone in reflections
+  * Never repeat the user’s text verbatim — paraphrase for clarity or insight
+  * Store AI response in a field like `ai_summary` in `journal_entries`
+
+### 6. Test Fixtures & Debugging
+
+* Store mock Telegram payloads in `.test/fixtures/*.json`
+* Name test users consistently: `user_0001`, `user_0002`, etc.
+* Simulate all input types: button press, free text, habit logs, journal routines
+
+---
+
+## ✅ Conventions Summary
+
+* Maintain `schema.json` integrity
+* Log in `CHANGELOG.md`
+* Track progress via `tasks.md`
+* Follow prompt design and AI tone rules
+* Use only Telegraf.js-compatible message formats
+
+---
+
+## 🧩 Optional Extensions
+
+* Add auto-validator for schema to compare PocketBase live schema vs `schema.json`
+* Create test generators for habit logs and journal entries
+
+> TELO is a mindful assistant, not just a productivity tool. Build with intention, empathy, and simplicity.


### PR DESCRIPTION
## Summary
- expand Development Roadmap section with detailed phases
- add `agents.txt` for AI helper notes
- introduce `.dev/` directory with task list and changelog

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861b895ada4832ca29c97475d1046b1