### PR TITLE
Add PocketBase schema and helper

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## [Unreleased]
 - Initial setup of agents files and updated documentation.
+- Added PocketBase schema and connection utility.

--- a/.dev/schema.json
+++ b/.dev/schema.json
@@ -1,0 +1,67 @@
+{
+  "collections": [
+    {
+      "name": "users",
+      "type": "base",
+      "schema": [
+        { "name": "goal", "type": "text", "required": false },
+        { "name": "quotes", "type": "json", "required": false },
+        { "name": "habits", "type": "json", "required": false }
+      ],
+      "indexes": [],
+      "listRule": "",
+      "viewRule": "",
+      "createRule": "",
+      "updateRule": "",
+      "deleteRule": ""
+    },
+    {
+      "name": "journal_entries",
+      "type": "base",
+      "schema": [
+        { "name": "user_id", "type": "text", "required": true },
+        { "name": "routine_type", "type": "text", "required": true },
+        { "name": "answers", "type": "json", "required": true }
+      ],
+      "indexes": [],
+      "listRule": "",
+      "viewRule": "",
+      "createRule": "",
+      "updateRule": "",
+      "deleteRule": ""
+    },
+    {
+      "name": "habit_logs",
+      "type": "base",
+      "schema": [
+        { "name": "user_id", "type": "text", "required": true },
+        { "name": "habit_name", "type": "text", "required": true },
+        { "name": "date", "type": "text", "required": true },
+        { "name": "count", "type": "number", "required": true }
+      ],
+      "indexes": [],
+      "listRule": "",
+      "viewRule": "",
+      "createRule": "",
+      "updateRule": "",
+      "deleteRule": ""
+    },
+    {
+      "name": "work_sessions",
+      "type": "base",
+      "schema": [
+        { "name": "user_id", "type": "text", "required": true },
+        { "name": "date", "type": "text", "required": true },
+        { "name": "total_minutes", "type": "number", "required": true },
+        { "name": "sprint_count", "type": "number", "required": true },
+        { "name": "reflections", "type": "json", "required": false }
+      ],
+      "indexes": [],
+      "listRule": "",
+      "viewRule": "",
+      "createRule": "",
+      "updateRule": "",
+      "deleteRule": ""
+    }
+  ]
+}

--- a/.dev/tasks.md
+++ b/.dev/tasks.md
@@ -2,8 +2,8 @@
 
 This list helps human and AI contributors coordinate work.
 
-- [ ] Set up Telegram bot with Telegraf.js
-- [ ] Configure PocketBase with required collections
+- [x] Set up Telegram bot with Telegraf.js
+- [x] Configure PocketBase with required collections
 - [ ] Implement `/start` onboarding flow
 - [ ] Add journaling feature
 - [ ] Add work mode with Pomodoro cycles

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "dotenv": "^16.3.1",
+    "pocketbase": "^0.26.1",
     "telegraf": "^4.12.2"
   }
 }

--- a/pb.js
+++ b/pb.js
@@ -1,0 +1,6 @@
+require('dotenv').config();
+const PocketBase = require('pocketbase/cjs');
+
+const pb = new PocketBase(process.env.POCKETBASE_URL);
+
+module.exports = pb;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
+      pocketbase:
+        specifier: ^0.26.1
+        version: 0.26.1
       telegraf:
         specifier: ^4.12.2
         version: 4.16.3
@@ -162,6 +165,9 @@ packages:
   p-timeout@4.1.0:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
     engines: {node: '>=10'}
+
+  pocketbase@0.26.1:
+    resolution: {integrity: sha512-fjcPDpxyqTZCwqGUTPUV7vssIsNMqHxk9GxbhxYHPEf18RqX2d9cpSqbbHk7aas30jqkgptuKfG7aY/Mytjj3g==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -313,6 +319,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   p-timeout@4.1.0: {}
+
+  pocketbase@0.26.1: {}
 
   proxy-from-env@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- mark tasks for Telegraf setup and PocketBase collections as done
- track new schema file in changelog
- create `.dev/schema.json` defining main PocketBase collections
- add `pb.js` helper and pocketbase dependency

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./pb'); console.log('pb ok')"`

------
https://chatgpt.com/codex/tasks/task_e_686425ef5fa0832ca23c146bc8c8764e