### PR TITLE
Refine onboarding flow with profile questions

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [Unreleased]
 - Initial setup of agents files and updated documentation.
 - Added PocketBase schema and connection utility.
+- Implemented `/start` onboarding flow with PocketBase user storage.
+- Added simple journaling workflow and stored user profile fields.
+- Enhanced onboarding to ask for first name, username, goal and optional
+  favourite quotes.

--- a/.dev/schema.json
+++ b/.dev/schema.json
@@ -4,6 +4,9 @@
       "name": "users",
       "type": "base",
       "schema": [
+        { "name": "user_id", "type": "text", "required": true },
+        { "name": "first_name", "type": "text", "required": false },
+        { "name": "username", "type": "text", "required": false },
         { "name": "goal", "type": "text", "required": false },
         { "name": "quotes", "type": "json", "required": false },
         { "name": "habits", "type": "json", "required": false }

--- a/.dev/tasks.md
+++ b/.dev/tasks.md
@@ -4,8 +4,8 @@ This list helps human and AI contributors coordinate work.
 
 - [x] Set up Telegram bot with Telegraf.js
 - [x] Configure PocketBase with required collections
-- [ ] Implement `/start` onboarding flow
-- [ ] Add journaling feature
+- [x] Implement `/start` onboarding flow
+- [x] Add journaling feature
 - [ ] Add work mode with Pomodoro cycles
 - [ ] Implement habit tracking
 - [ ] Show daily dashboard summary

--- a/pb_schema_users.json
+++ b/pb_schema_users.json
@@ -1,0 +1,18 @@
+{
+  "name": "users",
+  "type": "base",
+  "schema": [
+    { "name": "user_id", "type": "text", "required": true },
+    { "name": "first_name", "type": "text", "required": false },
+    { "name": "username", "type": "text", "required": false },
+    { "name": "goal", "type": "text", "required": false },
+    { "name": "quotes", "type": "json", "required": false },
+    { "name": "habits", "type": "json", "required": false }
+  ],
+  "indexes": [],
+  "listRule": "",
+  "viewRule": "",
+  "createRule": "",
+  "updateRule": "",
+  "deleteRule": ""
+}

--- a/workflows/journal.js
+++ b/workflows/journal.js
@@ -1,0 +1,30 @@
+const pb = require('../pb');
+const { sendMainMenu } = require('./menu');
+
+const awaitingEntry = {};
+
+async function start(ctx) {
+  const userId = String(ctx.from.id);
+  awaitingEntry[userId] = true;
+  await ctx.reply('What would you like to journal about today?', {
+    reply_markup: { force_reply: true },
+  });
+}
+
+async function handleText(ctx) {
+  const userId = String(ctx.from.id);
+  if (!awaitingEntry[userId]) return false;
+
+  await pb.collection('journal_entries').create({
+    user_id: userId,
+    routine_type: 'free',
+    answers: { text: ctx.message.text },
+  });
+
+  awaitingEntry[userId] = false;
+  await ctx.reply('Journal entry saved.');
+  await sendMainMenu(ctx);
+  return true;
+}
+
+module.exports = { start, handleText };

--- a/workflows/menu.js
+++ b/workflows/menu.js
@@ -1,0 +1,13 @@
+const { Markup } = require('telegraf');
+
+function sendMainMenu(ctx) {
+  return ctx.reply(
+    'Choose an option:',
+    Markup.inlineKeyboard([
+      [Markup.button.callback('Journal', 'menu:journal')],
+      [Markup.button.callback('Quotes', 'menu:quotes')],
+    ])
+  );
+}
+
+module.exports = { sendMainMenu };

--- a/workflows/onboarding.js
+++ b/workflows/onboarding.js
@@ -1,0 +1,112 @@
+const pb = require('../pb');
+const { Markup } = require('telegraf');
+const { sendMainMenu } = require('./menu');
+
+const onboardingState = {};
+
+async function start(ctx) {
+  const userId = String(ctx.from.id);
+  let user;
+  try {
+    user = await pb.collection('users').getFirstListItem(`user_id="${userId}"`);
+  } catch (e) {
+    user = null;
+  }
+
+  if (!user) {
+    onboardingState[userId] = { stage: 'first_name', data: {} };
+    await ctx.reply(
+      "👋 Welcome to TELO! I'm here to help you focus and reflect each day. Let's set up your profile."
+    );
+    return ctx.reply('What is your first name?', {
+      reply_markup: { force_reply: true },
+    });
+  }
+
+  return sendMainMenu(ctx);
+}
+
+async function handleText(ctx) {
+  const userId = String(ctx.from.id);
+  const state = onboardingState[userId];
+  if (!state) return false;
+
+  if (state.stage === 'first_name') {
+    state.data.first_name = ctx.message.text.trim();
+    state.stage = 'username';
+    await ctx.reply('Great! What username should I call you?', {
+      reply_markup: { force_reply: true },
+    });
+    return true;
+  }
+
+  if (state.stage === 'username') {
+    state.data.username = ctx.message.text.trim();
+    state.stage = 'goal';
+    await ctx.reply('Thanks! What is your main goal right now?', {
+      reply_markup: { force_reply: true },
+    });
+    return true;
+  }
+
+  if (state.stage === 'goal') {
+    state.data.goal = ctx.message.text.trim();
+    state.stage = 'quotes_prompt';
+    await ctx.reply(
+      'Would you like to add a favourite quote?',
+      Markup.inlineKeyboard([
+        Markup.button.callback('Yes', 'ob:yes'),
+        Markup.button.callback('No', 'ob:no'),
+      ])
+    );
+    return true;
+  }
+
+  if (state.stage === 'quotes') {
+    state.data.quotes = [ctx.message.text.trim()];
+    await finalize(ctx, userId, state.data);
+    return true;
+  }
+
+  return false;
+}
+
+async function handleAction(ctx) {
+  const userId = String(ctx.from.id);
+  const state = onboardingState[userId];
+  if (!state) return false;
+
+  if (ctx.callbackQuery.data === 'ob:yes') {
+    state.stage = 'quotes';
+    await ctx.editMessageText('Awesome! Send me your favourite quote:', {
+      reply_markup: { force_reply: true },
+    });
+    return true;
+  }
+
+  if (ctx.callbackQuery.data === 'ob:no') {
+    state.data.quotes = [];
+    await ctx.editMessageText('No problem, we can add quotes later.');
+    await finalize(ctx, userId, state.data);
+    return true;
+  }
+
+  return false;
+}
+
+async function finalize(ctx, userId, data) {
+  await pb.collection('users').create({
+    user_id: userId,
+    first_name: data.first_name,
+    username: data.username,
+    goal: data.goal,
+    quotes: data.quotes,
+  });
+  delete onboardingState[userId];
+  await ctx.reply(
+    "You're all set! Let's make every day intentional and productive. 🚀"
+  );
+  await sendMainMenu(ctx);
+}
+
+module.exports = { start, handleText, handleAction };


### PR DESCRIPTION
## Summary
- collect first name, username, goal and optional quote during /start
- handle yes/no buttons for quote capture
- show a polished welcome and completion message
- log onboarding improvement in CHANGELOG

## Testing
- `pnpm install`
- `BOT_TOKEN=foo POCKETBASE_URL=http://example.com node index.js` *(fails: request to api.telegram.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_68648668c7d0832c938a6705212c2df6