### PR TITLE
Implement onboarding flow

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 - Initial setup of agents files and updated documentation.
 - Added PocketBase schema and connection utility.
+- Implemented `/start` onboarding flow.

--- a/.dev/tasks.md
+++ b/.dev/tasks.md
@@ -4,7 +4,7 @@ This list helps human and AI contributors coordinate work.
 
 - [x] Set up Telegram bot with Telegraf.js
 - [x] Configure PocketBase with required collections
-- [ ] Implement `/start` onboarding flow
+- [x] Implement `/start` onboarding flow
 - [ ] Add journaling feature
 - [ ] Add work mode with Pomodoro cycles
 - [ ] Implement habit tracking

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const bot = new Telegraf(process.env.BOT_TOKEN);
 const POCKETBASE_URL = process.env.POCKETBASE_URL;
 
-bot.start((ctx) => {
+function showMainMenu(ctx) {
   return ctx.reply(
     'Choose an option:',
     Markup.inlineKeyboard([
@@ -13,7 +13,9 @@ bot.start((ctx) => {
       [Markup.button.callback('Quotes', 'menu:quotes')],
     ])
   );
-});
+}
+
+require('./workflows/onboarding')(bot, showMainMenu);
 
 bot.action('menu:journal', async (ctx) => {
   await ctx.answerCbQuery();

--- a/workflows/onboarding.js
+++ b/workflows/onboarding.js
@@ -1,0 +1,68 @@
+const { Markup } = require('telegraf');
+const pb = require('../pb');
+
+function registerOnboarding(bot, showMainMenu) {
+  const state = {};
+
+  bot.start(async (ctx) => {
+    const userId = String(ctx.from.id);
+    let user;
+    try {
+      user = await pb.collection('users').getOne(userId);
+    } catch (e) {
+      user = null;
+    }
+    if (user) {
+      return showMainMenu(ctx);
+    }
+    state[userId] = { step: 'goal', data: { quotes: [], habits: [] } };
+    await ctx.reply('Welcome to TELO! What is your main personal goal?');
+  });
+
+  bot.on('text', async (ctx) => {
+    const userId = String(ctx.from.id);
+    const s = state[userId];
+    if (!s) return;
+    const text = ctx.message.text.trim();
+
+    if (s.step === 'goal') {
+      s.data.goal = text;
+      s.step = 'quotes';
+      s.quoteCount = 0;
+      return ctx.reply('Great! Share an inspirational quote (or type "skip" to skip).');
+    }
+
+    if (s.step === 'quotes') {
+      if (text.toLowerCase() !== 'skip') {
+        s.data.quotes.push(text);
+        s.quoteCount++;
+      }
+      if (s.quoteCount < 3 && text.toLowerCase() !== 'skip') {
+        return ctx.reply('Another quote? (or type "skip")');
+      }
+      s.step = 'goodHabit';
+      return ctx.reply('Name one good habit you want to build:');
+    }
+
+    if (s.step === 'goodHabit') {
+      s.data.habits.push({ name: text, type: 'good', count_today: 0 });
+      s.step = 'badHabit';
+      return ctx.reply('Name one bad habit you want to reduce:');
+    }
+
+    if (s.step === 'badHabit') {
+      s.data.habits.push({ name: text, type: 'bad', count_today: 0 });
+      try {
+        await pb.collection('users').create({ id: userId, ...s.data });
+        await ctx.reply('Onboarding complete!');
+      } catch (e) {
+        console.error('Failed to save user', e.message);
+        await ctx.reply('Sorry, failed to save your data.');
+      }
+      delete state[userId];
+      return showMainMenu(ctx);
+    }
+  });
+}
+
+module.exports = registerOnboarding;


### PR DESCRIPTION
## Summary
- implement `/start` onboarding flow to collect goal, quotes, and habits
- expose onboarding logic under `workflows/onboarding.js`
- integrate onboarding workflow into the bot
- update tasks and changelog

## Testing
- `node -c index.js`
- `node -c workflows/onboarding.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868bb2cf954832c9b90848041e2c4ed