### PR TITLE
Fix onboarding quote prompt freeze

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -7,3 +7,5 @@
 - Added simple journaling workflow and stored user profile fields.
 - Enhanced onboarding to ask for first name, username, goal and optional
   favourite quotes.
+- Fixed onboarding flow freeze when entering a quote by sending a new
+  message with ForceReply.

--- a/workflows/onboarding.js
+++ b/workflows/onboarding.js
@@ -78,7 +78,8 @@ async function handleAction(ctx) {
 
   if (ctx.callbackQuery.data === 'ob:yes') {
     state.stage = 'quotes';
-    await ctx.editMessageText('Awesome! Send me your favourite quote:', {
+    await ctx.answerCbQuery();
+    await ctx.reply('Awesome! Send me your favourite quote:', {
       reply_markup: { force_reply: true },
     });
     return true;
@@ -86,6 +87,7 @@ async function handleAction(ctx) {
 
   if (ctx.callbackQuery.data === 'ob:no') {
     state.data.quotes = [];
+    await ctx.answerCbQuery();
     await ctx.editMessageText('No problem, we can add quotes later.');
     await finalize(ctx, userId, state.data);
     return true;


### PR DESCRIPTION
## Summary
- handle callback queries properly in onboarding
- send quote prompt as a new message so ForceReply works
- document the fix in the changelog

## Testing
- `node --check index.js`
- `node --check workflows/onboarding.js`


------
https://chatgpt.com/codex/tasks/task_e_6868f1624e90832c84808e467b6b7cdc