### PR TITLE
Fix start script env loading

### DIFF
--- a/.dev/CHANGELOG.md
+++ b/.dev/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added Nixpacks deployment with PocketBase setup script.
 - Initial setup of agents files and updated documentation.
 - Added PocketBase schema and connection utility.
 - Implemented `/start` onboarding flow with PocketBase user storage.
@@ -9,3 +10,5 @@
   favourite quotes.
 - Fixed onboarding flow freeze when entering a quote by sending a new
   message with ForceReply.
+- Fixed deployment start script to load `.env` so `superuser upsert` works
+  without missing email errors.

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 BOT_TOKEN=your_telegram_bot_token
-POCKETBASE_URL=http://your-pocketbase-url
+POCKETBASE_URL=http://localhost:8090
+PB_ADMIN_EMAIL=admin@me.com
+PB_ADMIN_PASSWORD=TeloAdmin123

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: bash start.sh

--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ TELO is designed to:
 
 ---
 
+## Deployment with Nixpacks
+
+1. Provide `BOT_TOKEN`, `PB_ADMIN_EMAIL`, and `PB_ADMIN_PASSWORD` via your host
+   environment or by editing `.env` (it will fall back to `.env.example` if no
+   `.env` is present).
+2. Deploy to any platform supporting [Nixpacks](https://nixpacks.com/).
+3. On start, `start.sh` loads the env vars, launches PocketBase and the bot,
+   imports `.dev/schema.json`, and seeds the admin if missing.
+
+
 ## Final Notes
 
 TELO isn’t just another productivity tool. It’s a **daily reflection mirror**, a **mini-habit coach**, and a **guided awareness builder** — all inside Telegram.

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,8 @@
+[phases.install]
+cmds = [
+  "pnpm install",
+  "chmod +x pocketbase/pocketbase"
+]
+
+[start]
+cmd = "bash start.sh"

--- a/scripts/initPocketBase.js
+++ b/scripts/initPocketBase.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+const fs = require('fs');
+const PocketBase = require('pocketbase/cjs');
+
+const pb = new PocketBase(process.env.POCKETBASE_URL || 'http://127.0.0.1:8090');
+const adminEmail = process.env.PB_ADMIN_EMAIL || 'admin@me.com';
+const adminPassword = process.env.PB_ADMIN_PASSWORD || 'TeloAdmin123';
+
+async function waitForHealth() {
+  for (let i = 0; i < 10; i++) {
+    try {
+      await pb.health.check();
+      return;
+    } catch (e) {
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  }
+  throw new Error('PocketBase did not start in time');
+}
+
+(async () => {
+  await waitForHealth();
+
+  try {
+    await pb.admins.authWithPassword(adminEmail, adminPassword);
+  } catch (err) {
+    await pb.admins.create({
+      email: adminEmail,
+      password: adminPassword,
+      passwordConfirm: adminPassword,
+    });
+    await pb.admins.authWithPassword(adminEmail, adminPassword);
+  }
+
+  const schema = JSON.parse(fs.readFileSync('.dev/schema.json', 'utf8'));
+  await pb.collections.import(schema.collections, true);
+  pb.authStore.clear();
+})();

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# load environment variables if .env is present
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+elif [ -f .env.example ]; then
+  set -a
+  . ./.env.example
+  set +a
+fi
+
+PB_DIR="${PB_DIR:-pb_data}"
+mkdir -p "$PB_DIR"
+
+# ensure pocketbase binary is executable
+chmod +x pocketbase/pocketbase
+
+# ensure admin account exists
+./pocketbase/pocketbase superuser upsert "$PB_ADMIN_EMAIL" "$PB_ADMIN_PASSWORD" --dir "$PB_DIR"
+
+# start pocketbase
+./pocketbase/pocketbase serve --http 0.0.0.0:8090 --dir "$PB_DIR" &
+PB_PID=$!
+
+export POCKETBASE_URL=${POCKETBASE_URL:-http://127.0.0.1:8090}
+
+# wait for pb to be up then import schema and seed data
+node scripts/initPocketBase.js
+
+# start the Telegram bot
+node index.js &
+NODE_PID=$!
+
+wait -n $NODE_PID $PB_PID


### PR DESCRIPTION
## Summary
- load `.env` or `.env.example` in `start.sh`
- document the env loading in deployment section
- note change in changelog

## Testing
- `node -e "require('./scripts/initPocketBase.js');"` *(fails: PocketBase not running)*

------
https://chatgpt.com/codex/tasks/task_e_6869a05bba94832cac19cf78f18c8f12